### PR TITLE
Reverting timeout in sonic-sairedis

### DIFF
--- a/lib/inc/sairedis.h
+++ b/lib/inc/sairedis.h
@@ -20,7 +20,7 @@ const std::string objectTypeGetAvailabilityResponse("object_type_get_availabilit
 /**
  * @brief Default synchronous operation response timeout in milliseconds.
  */
-#define SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT (6*60*1000)
+#define SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT (60*1000)
 
 typedef enum _sai_redis_notify_syncd_t
 {


### PR DESCRIPTION
Reverting timeout from 6 min to 1 min in sonic-sairedis for testing